### PR TITLE
fix(threejs): use nullish coalescing for createLight option

### DIFF
--- a/src/threejs/threejs-scene.ts
+++ b/src/threejs/threejs-scene.ts
@@ -67,7 +67,7 @@ export class ThreejsSceneLayer implements CustomLayerInterface {
 
         this._map.transform.setOrthographicProjectionAtLowPitch(false);
 
-        this._scene = this._helper.createScene(this._options.createLight || true);
+        this._scene = this._helper.createScene(this._options.createLight ?? true);
         this._sceneRoot = this._helper.createGroup(this._scene, 'scene-root');
         this._camera = this._helper.createCamera(this._sceneRoot, 'camera-for-render');
 


### PR DESCRIPTION
The change replaces the logical OR (||) with nullish coalescing (??) operator to properly handle falsy values in the createLight option while maintaining the default true behavior when undefined.